### PR TITLE
feat:fix a bug 

### DIFF
--- a/gearbox_test.go
+++ b/gearbox_test.go
@@ -122,7 +122,7 @@ var handler = func(ctx Context) {}
 var errorHandler = func(ctx Context) {
 	m := make(map[string]int)
 	m["a"] = 0
-	ctx.SendString(string(5 / m["a"]))
+	ctx.SendString(string(rune(5 / m["a"])))
 }
 
 // headerHandler echos header's value of key "my-header"


### PR DESCRIPTION
in mac os Goland  An error will be reported at runtime
`# github.com/gogearbox/gearbox
./gearbox_test.go:125:17: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)`
