### PR TITLE
Add trella to gearbox's users section in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,8 +207,8 @@ Organizations that are helping to manage, promote, and support **Gearbox** :gear
 ### Who uses Gearbox
 **Gearbox** :gear: is being used by multiple organizations including but not limited to 
 
-[<img src="https://raw.githubusercontent.com/gogearbox/gearbox/master/assets/erply-user.png"/>](https://erply.com) 		
-
+[<img src="https://raw.githubusercontent.com/gogearbox/gearbox/master/assets/erply-user.png"/>](https://erply.com)	
+[<img src="https://raw.githubusercontent.com/gogearbox/gearbox/master/assets/trella-sponsor.png"/>](https://www.trella.app)
 
 
 ### Contributors


### PR DESCRIPTION
Changes proposed in this pull request:
- Add trella to gearbox's users section in Readme
-
-
